### PR TITLE
Basic testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,4 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^\.travis\.yml$
+^codecov\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+src/*.o
+src/*.so
+src/*.dll

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+sudo: false
+cache: packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,20 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: R
+dist: trusty
 sudo: false
 cache: packages
+
+r_binary_packages:
+  - bigalgebra
+  - biganalytics
+  - bigmemory
+  - covr
+  - devtools
+  - ggplot2
+  - knitr
+  - Rcpp
+  - rmarkdown
+  - roxygen2
+  - shiny
+  - testthat

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,9 @@ dist: trusty
 sudo: false
 cache: packages
 warnings_are_errors: false
+
+r_github_packages:
+  - jimhester/covr
+
+after_success:
+  - Rscript -e 'covr::codecov()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,3 @@ language: R
 dist: trusty
 sudo: false
 cache: packages
-
-r_binary_packages:
-  - bigalgebra
-  - biganalytics
-  - bigmemory
-  - covr
-  - devtools
-  - ggplot2
-  - knitr
-  - Rcpp
-  - rmarkdown
-  - roxygen2
-  - shiny
-  - testthat

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ language: R
 dist: trusty
 sudo: false
 cache: packages
+warnings_are_errors: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,10 +27,10 @@ Depends:
   R (>= 3.3.0)
 RoxygenNote: 6.0.1
 Suggests:
-    covr,
-    knitr,
-    rmarkdown,
-    testthat
+  covr,
+  knitr,
+  rmarkdown,
+  testthat
 VignetteBuilder: knitr
 NeedsCompilation: yes
 Packaged: 2017-05-08 22:24:02 UTC; mohanty

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,8 @@ Description: Functions for Kernel-Regularized Least Squares optimized for speed 
 License: GPL (>= 2)
 Imports: 
   bigalgebra,
-  biganalytics,,
-  bigmemory
+  biganalytics,
+  bigmemory,
   ggplot2,
   parallel,
   Rcpp (>= 0.12.4), 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ License: GPL (>= 2)
 Imports: 
   bigalgebra,
   biganalytics,
-  bigmemory,
   ggplot2,
   parallel,
   Rcpp (>= 0.12.4), 
@@ -24,7 +23,8 @@ LinkingTo:
   Rcpp, 
   RcppArmadillo
 Depends:
-  R (>= 3.3.0)
+  R (>= 3.3.0),
+  bigmemory
 RoxygenNote: 6.0.1
 Suggests:
   covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,12 +10,27 @@ Authors@R: c(person("Pete", "Mohanty", role = c("aut", "cre"),
 Description: Functions for Kernel-Regularized Least Squares optimized for speed and memory usage are provided along with visualization tools. 
   For working papers, sample code, and recent presentations visit <https://sites.google.com/site/petemohanty/software/>.
 License: GPL (>= 2)
-Imports: Rcpp (>= 0.12.4), biganalytics, bigalgebra, shiny, parallel,
-        ggplot2
-LinkingTo: Rcpp, RcppArmadillo, bigmemory, BH
-Depends: R (>= 3.3.0), bigmemory
+Imports: 
+  bigalgebra,
+  biganalytics,,
+  bigmemory
+  ggplot2,
+  parallel,
+  Rcpp (>= 0.12.4), 
+  shiny
+LinkingTo:
+  bigmemory,
+  BH,
+  Rcpp, 
+  RcppArmadillo
+Depends:
+  R (>= 3.3.0)
 RoxygenNote: 6.0.1
-Suggests: knitr, rmarkdown
+Suggests:
+    covr,
+    knitr,
+    rmarkdown,
+    testthat
 VignetteBuilder: knitr
 NeedsCompilation: yes
 Packaged: 2017-05-08 22:24:02 UTC; mohanty

--- a/R/bigKRLS.R
+++ b/R/bigKRLS.R
@@ -891,9 +891,13 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
     newname = name
   }
   class(bigKRLS_out) <- "bigKRLS"
-  assign(newname, bigKRLS_out, envir = as.environment(pos))
-  cat("New bigKRLS object created named", newname, "with", length(bigKRLS_out), "out of 21 possible elements of the bigKRLS class.\n\nOptions for this object include: summary(), predict(), and shiny.bigKRLS().\nRun vignette(\"bigKRLS_basics\") for detail")
+  if(!is.na(pos)) {
+    assign(newname, bigKRLS_out, envir = as.environment(pos))
+    cat("New bigKRLS object created named", newname, "with", length(bigKRLS_out), "out of 21 possible elements of the bigKRLS class.\n\nOptions for this object include: summary(), predict(), and shiny.bigKRLS().\nRun vignette(\"bigKRLS_basics\") for detail")
+  }
+  
   setwd(wd.original)
+  bigKRLS_out
 }
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # bigKRLS
+[![Travis-CI Build Status](https://travis-ci.org/peterfoley/bigKRLS.svg?branch=basic_testing)](https://travis-ci.org/peterfoley/bigKRLS)
+[![Coverage Status](https://img.shields.io/codecov/c/github/peterfoley/bigKRLS/basic_testing.svg)](https://codecov.io/github/peterfoley/bigKRLS?branch=basic_testing)
+
 Kernel Regularized Least Squares (KRLS) is a kernel-based, complexity-penalized method developed by [Hainmueller and Hazlett (2013)](http://pan.oxfordjournals.org/content/22/2/143), and designed to minimize parametric assumptions while maintaining interpretive clarity. Here, we introduce *bigKRLS*, an updated version of the original [KRLS R package](https://CRAN.R-project.org/package=KRLS) with algorithmic and implementation improvements designed to optimize speed and memory usage. These improvements allow users to straightforwardly estimate pairwise regression models with KRLS once N > ~2500. *bigKRLS* is now available on CRAN.
 
 # Major Updates

--- a/bigKRLS.Rproj
+++ b/bigKRLS.Rproj
@@ -1,0 +1,19 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: XeLaTeX
+
+AutoAppendNewline: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(bigKRLS)
+
+test_check("bigKRLS")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,8 @@
 library(testthat)
 library(bigKRLS)
 
+# have to disable R_TESTS environment variable or parallel::makePSOCKcluster hangs.
+Sys.setenv("R_TESTS" = "")
+
+
 test_check("bigKRLS")

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,0 +1,2 @@
+bigKRLS_test_results
+bigKRLS_test_bigmemory_results

--- a/tests/testthat/test_basic_usage.R
+++ b/tests/testthat/test_basic_usage.R
@@ -7,12 +7,14 @@ y = as.matrix(mtcars$mpg)
 X = as.matrix(mtcars[,-1])
 
 test_equivalent_models <- function(mod1, mod2) {
+  # ignore any path differences
+  mod1$path <- mod2$path <- NULL
   # ignore differences in name sorting 
   expect_identical(sort(names(mod1)), sort(names(mod2)))
   mod2 <- mod2[names(mod1)]
   
   # check that most elements are identical, except for expected handful
-  identical_elements <- mapply(identical, out, out2[names(out)])
+  identical_elements <- mapply(identical, mod1, mod2[names(mod1)])
   names_to_check <- sort(names(which(!identical_elements)))
   allowed_not_identical <- c("derivatives", "K", "path", "vcov.est.c", "X")
   expect_true(all(names_to_check %in% allowed_not_identical))
@@ -92,7 +94,7 @@ test_that("Simple example works", {
                   'Volvo 142E'=0.78179636900690)
   expect_identical(names(s), names(s_expected))
   s_difference <- s-s_expected
-  expect_less_than(max(s_difference), 0.01)
+  expect_lt(max(s_difference), 0.01)
 })
 
 

--- a/tests/testthat/test_basic_usage.R
+++ b/tests/testthat/test_basic_usage.R
@@ -1,0 +1,114 @@
+# test the basic usage in the package documentation works
+context("Basic usage")
+
+# prep data to use for testing
+mtcars <- datasets::mtcars
+y = as.matrix(mtcars$mpg)
+X = as.matrix(mtcars[,-1])
+
+test_equivalent_models <- function(mod1, mod2) {
+  # ignore differences in name sorting 
+  expect_identical(sort(names(mod1)), sort(names(mod2)))
+  mod2 <- mod2[names(mod1)]
+  
+  # check that most elements are identical, except for expected handful
+  identical_elements <- mapply(identical, out, out2[names(out)])
+  names_to_check <- sort(names(which(!identical_elements)))
+  allowed_not_identical <- c("derivatives", "K", "path", "vcov.est.c", "X")
+  expect_true(all(names_to_check %in% allowed_not_identical))
+  
+  # allow some fields to just be nearly equal
+  allowed_nearly_equal <- c("derivatives", "K", "vcov.est.c", "X")
+  for(v in intersect(names_to_check, allowed_nearly_equal)) {
+    expect_equivalent(as.matrix(mod1[[v]]), as.matrix(mod2[[v]]), info = paste0("v = ",v))
+  }
+  names_to_check <- setdiff(names_to_check, allowed_nearly_equal)
+  
+  # allow some fields to be different
+  names_to_check <- setdiff(names_to_check, "path")
+  
+  # should have nothing left to check
+  expect_identical(names_to_check, character(0), info=paste0("names_to_check = ", paste(names_to_check, collapse=", ")))
+  
+  invisible(NULL)
+}
+
+
+test_that("Simple example works", {
+  # fitting
+  reg.out <- bigKRLS(y = y, X = X, noisy=F, Ncores = 2)
+  
+  # saving/loading with normal matrices
+  model_subfolder <- "bigKRLS_test_results"
+  save.bigKRLS(reg.out, model_subfolder, overwrite.existing = TRUE)
+  reg.out2 <- load.bigKRLS(model_subfolder, pos=NA)
+  # test that saved object is equivalent
+  test_equivalent_models(reg.out, reg.out2)
+  # remove subfolder
+  unlink(model_subfolder, recursive = TRUE)
+  
+  # prediction
+  Xnew <- datasets::mtcars[,-1]
+  Xnew$hp <- 200
+  forecast <- predict(reg.out, as.matrix(Xnew))
+  expect_equal(mean(forecast$fit < mtcars$mpg), 0.6875)
+  
+  # similarity
+  
+  s <- reg.out$K[, grep("Corolla", rownames(mtcars))]
+  names(s) <- rownames(mtcars)
+  s <- s[order(names(s))]
+  s_expected <- c('AMC Javelin'=0.0547298949171582, 
+                  'Cadillac Fleetwood'=0.00549165470976291, 
+                  'Camaro Z28'=0.0156630175526991, 
+                  'Chrysler Imperial'=0.0060180975553816, 
+                  'Datsun 710'=0.860610665218997, 
+                  'Dodge Challenger'=0.033400030235352, 
+                  'Duster 360'=0.0143264812794483, 
+                  'Ferrari Dino'=0.062192422562695, 
+                  'Fiat 128'=0.973400786036153, 
+                  'Fiat X1-9'=0.961130622208994, 
+                  'Ford Pantera L'=0.0207382308766512, 
+                  'Honda Civic'=0.753451355337079, 
+                  'Hornet 4 Drive'=0.19371687432462, 
+                  'Hornet Sportabout'=0.0388127837578353, 
+                  'Lincoln Continental'=0.00503976771060228, 
+                  'Lotus Europa'=0.528183252015446, 
+                  'Maserati Bora'=0.00201340749064979, 
+                  'Mazda RX4'=0.239466325088983, 
+                  'Mazda RX4 Wag'=0.254841103009284, 
+                  'Merc 230'=0.373560094613131, 
+                  'Merc 240D'=0.464081081884477, 
+                  'Merc 280'=0.250345020593959, 
+                  'Merc 280C'=0.262879139614823, 
+                  'Merc 450SE'=0.0344532182858226, 
+                  'Merc 450SL'=0.0411135560575867, 
+                  'Merc 450SLC'=0.0424741434773812, 
+                  'Pontiac Firebird'=0.0270102739090449, 
+                  'Porsche 914-2'=0.3709635022494, 
+                  'Toyota Corolla'=1, 
+                  'Toyota Corona'=0.468060548244946, 
+                  'Valiant'=0.146078393891752, 
+                  'Volvo 142E'=0.78179636900690)
+  expect_identical(names(s), names(s_expected))
+  s_difference <- s-s_expected
+  expect_less_than(max(s_difference), 0.01)
+})
+
+
+test_that("bigmemory example works", {
+  model_subfolder <- "bigKRLS_test_bigmemory_results"
+  big <- bigKRLS(
+    y = as.big.matrix(y),
+    X = as.big.matrix(X),
+    Ncores = 2,
+    model_subfolder_name = model_subfolder,
+    overwrite.existing = TRUE
+  )
+  
+  # compare saved model and loaded model
+  big2 <- load.bigKRLS(model_subfolder, pos=NA)
+  test_equivalent_models(big, big2)
+  
+  unlink(model_subfolder)
+})

--- a/tests/testthat/test_basic_usage.R
+++ b/tests/testthat/test_basic_usage.R
@@ -112,5 +112,5 @@ test_that("bigmemory example works", {
   big2 <- load.bigKRLS(model_subfolder, pos=NA)
   test_equivalent_models(big, big2)
   
-  unlink(model_subfolder)
+  unlink(model_subfolder, recursive = TRUE)
 })

--- a/vignettes/bigKRLS_basics.Rmd
+++ b/vignettes/bigKRLS_basics.Rmd
@@ -19,6 +19,7 @@ bigKRLS is the workhorse of this package; there are only two basic inputs: a vec
 
 ```{r, echo=F, message=F, warning=F}
 library(bigKRLS)
+library(bigmemory)
 ```
 
 ```{r}

--- a/vignettes/bigKRLS_basics.Rmd
+++ b/vignettes/bigKRLS_basics.Rmd
@@ -19,7 +19,6 @@ bigKRLS is the workhorse of this package; there are only two basic inputs: a vec
 
 ```{r, echo=F, message=F, warning=F}
 library(bigKRLS)
-library(bigmemory)
 ```
 
 ```{r}


### PR DESCRIPTION
This PR adds in basic tests using testthat and sets up travis and codecov.

Test implementation required changing load.bigKRLS to be able to return the loaded object into the local rather than the global environment. It currently does that when `pos=NA` is passed. Would recommend removing global environment writes altogether to simplify usage within more complex projects.

Before merging, will need to update the travis/codecov badge urls in README.md to point to `rdrr1990/bigKRLS` master rather than the `peterfoley/bigKRLS` fork.

