### PR TITLE
Never modify working directory

### DIFF
--- a/R/bigKRLS.R
+++ b/R/bigKRLS.R
@@ -835,13 +835,11 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
   
   stopifnot(is.null(newname) | is.character(newname))
   
-  wd.original <- getwd()
-  setwd(path)
-  files <- dir()
+  files <- dir(path = path)
   if(!("estimates.rdata" %in% files)){
     stop("estimates.rdata not found. Check the path to the output folder.\n\nNote: for any files saved manually, note that load.bigKRLS() anticipates the convention used by save.bigKRLS: estimates.rdata stores the base R objects in a list called bigKRLS_out, big matrices stored as text files named like they are in bigKRLS objects (object$K becomes K.txt, etc.).\n\n")
   }
-  name = load("estimates.rdata")
+  name = load(file.path(path, "estimates.rdata"))
   
   if(bigKRLS_out$has.big.matrices){ 
     cat("Loading big matrices from", getwd(), "\n\n")
@@ -850,7 +848,7 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
         cat("WARNING: Kernel not found in .rdata or in big matrix file K.txt\n\n")
       }else{
         cat("\tReading kernel from K.txt...\n")
-        bigKRLS_out$K <- read.big.matrix("K.txt", type = "double")
+        bigKRLS_out$K <- read.big.matrix(file.path(path, "K.txt"), type = "double")
       }
     }
     if(!("X" %in% names(bigKRLS_out))){
@@ -858,7 +856,7 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
         cat("WARNING: X matrix not found in .rdata or in big matrix file X.txt\n\n")
       }else{
         cat("\tReading X matrix from X.txt...\n")
-        bigKRLS_out$X <- read.big.matrix("X.txt", type = "double", header=T)
+        bigKRLS_out$X <- read.big.matrix(file.path(path, "X.txt"), type = "double", header=T)
       }
     }
     if(!("derivatives" %in% names(bigKRLS_out))){
@@ -866,7 +864,7 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
         cat("WARNING: derivatives matrix not found in .rdata or in big matrix file derivatives.txt\n\n")
       }else{
         cat("\tReading derivatives matrix from derivatives.txt...\n")
-        bigKRLS_out$derivatives <- read.big.matrix("derivatives.txt", type = "double", header=T)
+        bigKRLS_out$derivatives <- read.big.matrix(file.path(path, "derivatives.txt"), type = "double", header=T)
       }
     }
     if(!("vcov.est.c" %in% names(bigKRLS_out))){
@@ -874,7 +872,7 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
         cat("WARNING: variance covariance matrix of the coefficients not found in .rdata or in big matrix file vcov.est.c.txt (necessary to compute standard errors of predictions)\n\n")
       }else{
         cat("\tReading variance covariance matrix of the coefficients from vcov.est.c.txt...\n")
-        bigKRLS_out$vcov.est.c <- read.big.matrix("vcov.est.c.txt", type = "double")
+        bigKRLS_out$vcov.est.c <- read.big.matrix(file.path(path, "vcov.est.c.txt"), type = "double")
       }
     }
     if(!("vcov.est.fitted" %in% names(bigKRLS_out))){
@@ -882,7 +880,7 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
         cat("WARNING: variance covariance matrix of the fitted values not found in .rdata or in big matrix file vcov.est.fitted.txt\n\n")
       }else{
         cat("\tReading variance covariance matrix of the fitted values from vcov.est.fitted.txt...\n\n")
-        bigKRLS_out$vcov.est.fitted <- read.big.matrix("vcov.est.fitted.txt", type = "double")
+        bigKRLS_out$vcov.est.fitted <- read.big.matrix(file.path(path, "vcov.est.fitted.txt"), type = "double")
       }
     }
   }
@@ -895,7 +893,6 @@ load.bigKRLS <- function(path, newname = NULL, pos = 1){
     cat("New bigKRLS object created named", newname, "with", length(bigKRLS_out), "out of 21 possible elements of the bigKRLS class.\n\nOptions for this object include: summary(), predict(), and shiny.bigKRLS().\nRun vignette(\"bigKRLS_basics\") for detail")
   }
   
-  setwd(wd.original)
   bigKRLS_out
 }
 

--- a/R/bigKRLS.R
+++ b/R/bigKRLS.R
@@ -781,7 +781,7 @@ save.bigKRLS <- function (object, model_subfolder_name, overwrite.existing=F)
   }
   stopifnot(is.character(model_subfolder_name))
   
-  if(!overwrite.existing & (model_subfolder_name %in% dir())){
+  if(!overwrite.existing && dir.exists(model_subfolder_name)){
     i <- 1
     tmp.name <- paste(model_subfolder_name, i, sep="")
     while(tmp.name %in% dir()){
@@ -794,16 +794,15 @@ save.bigKRLS <- function (object, model_subfolder_name, overwrite.existing=F)
     model_subfolder_name <- tmp.name
   }
   
-  dir.create(model_subfolder_name)
-  wd.original <- getwd()
-  setwd(paste(c(wd.original, .Platform$file.sep, model_subfolder_name), collapse=""))
-  cat("Saving model estimates to:\n\n", getwd(), "\n\n")
-  object[["path"]] <- getwd()
+  dir.create(model_subfolder_name, showWarnings = FALSE)
+  cat("Saving model estimates to:\n\n", model_subfolder_name, "\n\n")
+  object[["path"]] <- normalizePath(model_subfolder_name)
   
   for(i in which(unlist(lapply(object, is.big.matrix)))){
-    cat("\twriting", paste(c(names(object)[i], ".txt"), collapse = ""), "...\n")
+    output_path <- file.path(model_subfolder_name, paste0(names(object)[i], ".txt"))
+    cat("\twriting", output_path, "...\n")
     write.big.matrix(x = object[[i]], col.names = !is.null(colnames(object[[i]])),
-                     filename = paste(c(names(object)[i], ".txt"), collapse = ""))
+                     filename = output_path)
   }
   
   Nbm <- sum(unlist(lapply(object, is.big.matrix)))
@@ -817,10 +816,10 @@ save.bigKRLS <- function (object, model_subfolder_name, overwrite.existing=F)
   }
   remove(object)
   stopifnot(sum(unlist(lapply(bigKRLS_out, is.big.matrix))) == 0)
-  save(bigKRLS_out, file="estimates.rdata")
+  save(bigKRLS_out, file=file.path(model_subfolder_name, "estimates.rdata"))
   cat("Smaller, base R elements of the outputted object saved in estimates.rdata.\n")
-  cat("Total file size approximately", round(sum(file.info(list.files())$size)/1024^2), "megabytes.")
-  setwd(wd.original) 
+  cat("Total file size approximately", round(sum(file.info(list.files(path = model_subfolder_name))$size)/1024^2), "megabytes.")
+  model_subfolder_name
 }
 
 #' load.bigKRLS

--- a/R/bigKRLS.R
+++ b/R/bigKRLS.R
@@ -304,7 +304,7 @@ bigKRLS <- function (y = NULL, X = NULL, sigma = NULL, derivative = TRUE, which.
       X.description = describe(X)
       K.description = describe(K)
       vcovmatc.description = describe(vcovmatc)
-      desc_subfolder <- if(is.null(model_subfolder_name)) '.' else model_subfolder_name
+      desc_subfolder <- if(is.null(model_subfolder_name)) tempdir() else model_subfolder_name
       dput(X.description, file=file.path(desc_subfolder, "X.desc"))
       dput(K.description, file=file.path(desc_subfolder, "K.desc"))
       dput(vcovmatc.description, file=file.path(desc_subfolder, "V.desc"))


### PR DESCRIPTION
This removes all working directory changes from the package but keeps the directory structure of saved objects unchanged with one exception -- temporary `.desc` files are placed in `tempdir()` rather than the working directory.

Note that this PR builds off the testing setup in #12, so after that's merged, this branch/PR should be rebased to `rdrr1990/bigKRLS/master` to simplify history.